### PR TITLE
fix: change rate limit key

### DIFF
--- a/claim-db-worker/src/index.ts
+++ b/claim-db-worker/src/index.ts
@@ -36,6 +36,9 @@ export default {
 
 		const { success } = await env.CLAIM_DB_RATE_LIMITER.limit({ key: clientIP! });
 
+		console.log(`Client IP: ${clientIP} - Request URL: ${request.url}`);
+		console.log(`Ray ID: ${rayId} - Request Method: ${request.method}`);
+
 		if (!success) {
 			console.log(`Rate limit exceeded for IP: ${clientIP}. Ray ID: ${rayId}. Request blocked to prevent abuse.`);
 			return new Response(

--- a/claim-db-worker/src/index.ts
+++ b/claim-db-worker/src/index.ts
@@ -31,8 +31,8 @@ export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
 		// --- Rate limiting ---
 		// Use client IP for consistent rate limiting across environments
-		const clientIP = request.headers.get('CF-Connecting-IP') || request.headers.get('X-Forwarded-For') || 'unknown';
-		const { success } = await env.CLAIM_DB_RATE_LIMITER.limit({ key: clientIP });
+		const clientIP = request.headers.get('x-agent') || request.headers.get('cf-connecting-ip');
+		const { success } = await env.CLAIM_DB_RATE_LIMITER.limit({ key: clientIP! });
 
 		if (!success) {
 			return errorResponse('Rate Limit Exceeded', "We're experiencing high demand. Please try again later.", '', 429);

--- a/claim-db-worker/src/index.ts
+++ b/claim-db-worker/src/index.ts
@@ -30,7 +30,9 @@ function errorResponse(title: string, message: string, details?: string, status 
 export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
 		// --- Rate limiting ---
-		const { success } = await env.CLAIM_DB_RATE_LIMITER.limit({ key: request.url });
+		// Use client IP for consistent rate limiting across environments
+		const clientIP = request.headers.get('CF-Connecting-IP') || request.headers.get('X-Forwarded-For') || 'unknown';
+		const { success } = await env.CLAIM_DB_RATE_LIMITER.limit({ key: clientIP });
 
 		if (!success) {
 			return errorResponse('Rate Limit Exceeded', "We're experiencing high demand. Please try again later.", '', 429);

--- a/claim-db-worker/src/index.ts
+++ b/claim-db-worker/src/index.ts
@@ -29,8 +29,6 @@ function errorResponse(title: string, message: string, details?: string, status 
 
 export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-		// --- Custom KV Rate limiting ---
-
 		// --- Rate limiting ---
 		// Use client IP for consistent rate limiting across environments
 		const clientIP = request.headers.get('x-agent') || request.headers.get('cf-connecting-ip');

--- a/claim-db-worker/wrangler.jsonc
+++ b/claim-db-worker/wrangler.jsonc
@@ -24,7 +24,7 @@
 				"type": "ratelimit",
 				"namespace_id": "1006",
 				"simple": {
-					"limit": 100,
+					"limit": 10,
 					"period": 60,
 				},
 			},

--- a/create-db-worker/src/index.ts
+++ b/create-db-worker/src/index.ts
@@ -13,8 +13,11 @@ export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
 		// --- Rate limiting ---
 		// Use client IP for consistent rate limiting across environments
-		const clientIP = request.headers.get('CF-Connecting-IP') || request.headers.get('X-Forwarded-For') || 'unknown';
-		const { success } = await env.CREATE_DB_RATE_LIMITER.limit({ key: clientIP });
+		const clientIP = request.headers.get('x-agent') || request.headers.get('cf-connecting-ip');
+
+		console.log(`Client IP: ${clientIP} - Request URL: ${request.url}`);
+
+		const { success } = await env.CREATE_DB_RATE_LIMITER.limit({ key: clientIP! });
 
 		if (!success) {
 			return new Response(`429 Failure - rate limit exceeded for ${request.url}`, { status: 429 });

--- a/create-db-worker/src/index.ts
+++ b/create-db-worker/src/index.ts
@@ -12,7 +12,9 @@ export { DeleteDbWorkflow };
 export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
 		// --- Rate limiting ---
-		const { success } = await env.CREATE_DB_RATE_LIMITER.limit({ key: request.url });
+		// Use client IP for consistent rate limiting across environments
+		const clientIP = request.headers.get('CF-Connecting-IP') || request.headers.get('X-Forwarded-For') || 'unknown';
+		const { success } = await env.CREATE_DB_RATE_LIMITER.limit({ key: clientIP });
 
 		if (!success) {
 			return new Response(`429 Failure - rate limit exceeded for ${request.url}`, { status: 429 });

--- a/create-db-worker/src/index.ts
+++ b/create-db-worker/src/index.ts
@@ -17,6 +17,7 @@ export default {
 		const rayId = request.headers.get('cf-ray') || request.headers.get('x-ray-id') || 'unknown-ray-id';
 
 		console.log(`Client IP: ${clientIP} - Request URL: ${request.url}`);
+		console.log(`Ray ID: ${rayId} - Request Method: ${request.method}`);
 
 		const { success } = await env.CREATE_DB_RATE_LIMITER.limit({ key: clientIP! });
 
@@ -27,8 +28,6 @@ export default {
 					error: 'Too Many Requests',
 					message: 'You have exceeded the allowed number of requests. Please wait before trying again.',
 					code: 429,
-					ip: clientIP,
-					rayId,
 				}),
 				{
 					status: 429,

--- a/create-db-worker/wrangler.jsonc
+++ b/create-db-worker/wrangler.jsonc
@@ -27,7 +27,7 @@
 				"type": "ratelimit",
 				"namespace_id": "1005",
 				"simple": {
-					"limit": 100,
+					"limit": 10,
 					"period": 60,
 				},
 			},

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "changeset": "changeset",
     "version": "changeset version",
     "publish:cli": "changeset publish --filter create-db",
-    "prepare": "node .husky/install.mjs"
+    "prepare": "node .husky/install.mjs",
+    "deploy-workers": "pnpm run deploy-create-db-worker && pnpm run deploy-claim-worker",
+    "deploy-claim-worker": "cd claim-db-worker && npx wrangler@latest deploy && cd ..",
+    "deploy-create-db-worker": "cd create-db-worker && npx wrangler@latest deploy"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.5",

--- a/tests/test-rate-limits.sh
+++ b/tests/test-rate-limits.sh
@@ -5,8 +5,8 @@
 
 # Default values
 TEST_COUNT=${1:-110}
-CREATE_DB_URL=${2:-"http://127.0.0.1:8787"}
-CLAIM_DB_URL=${3:-"http://127.0.0.1:9999"}
+CREATE_DB_URL=${2:-"https://create-db-temp.prisma.io"}
+CLAIM_DB_URL=${3:-"https://create-db.prisma.io"}
 
 echo "🧪 Testing Rate Limits"
 echo "======================"

--- a/tests/test-rate-limits.sh
+++ b/tests/test-rate-limits.sh
@@ -1,18 +1,21 @@
 #!/bin/bash
 
 # Test Rate Limits Script
-# Usage: ./tests/test-rate-limits.sh [test_count] [create_db_url] [claim_db_url]
+# Usage: ./tests/test-rate-limits.sh [test_count] [create_db_url] [claim_db_url] [agent_id]
 
 # Default values
 TEST_COUNT=${1:-110}
 CREATE_DB_URL=${2:-"https://create-db-temp.prisma.io"}
 CLAIM_DB_URL=${3:-"https://create-db.prisma.io"}
+AGENT_ID=${4:-"meow"}
 
 echo "🧪 Testing Rate Limits"
 echo "======================"
 echo "Test Count: $TEST_COUNT"
 echo "Create DB URL: $CREATE_DB_URL"
 echo "Claim DB URL: $CLAIM_DB_URL"
+echo "Agent Header: X-Agent: $AGENT_ID"
+echo "User-Agent: prisma-rate-limit-test/$AGENT_ID"
 echo ""
 
 # Function to test a worker
@@ -32,8 +35,15 @@ test_worker() {
     for i in $(seq 1 $TEST_COUNT); do
         echo -n "Request $i/$TEST_COUNT: "
         
-        # Make the request and capture both response body and status code
-        response=$(curl -s -w "%{http_code}" -o /tmp/response_$i.json "$endpoint" 2>/dev/null)
+        # Make the request with unique agent headers and capture body + status code
+        response=$(curl -s \
+          -H "x-agent: $AGENT_ID" \
+          -H "x-Agent: $AGENT_ID" \
+          -H "User-Agent: prisma-rate-limit-test/$AGENT_ID" \
+          -w "%{http_code}" \
+          -o /tmp/response_$i.json \
+          "$endpoint" 2>/dev/null)
+
         status_code=${response: -3}
         
         case $status_code in
@@ -52,7 +62,7 @@ test_worker() {
         esac
         
         # Small delay between requests
-        sleep 0.1
+        #sleep 0.05
     done
     
     echo ""
@@ -76,4 +86,4 @@ echo "- Later requests should be rate limited (429)"
 echo "- This confirms rate limiting is working correctly"
 echo ""
 echo "💡 To test with your actual deployed URLs, run:"
-echo "   ./tests/test-rate-limits.sh 110 https://create-db-temp.prisma.io https://create-db.prisma.io" 
+echo "   ./tests/test-rate-limits.sh 110 https://create-db-temp.prisma.io https://create-db.prisma.io my-local-agent"

--- a/tests/test-rate-limits.sh
+++ b/tests/test-rate-limits.sh
@@ -37,9 +37,6 @@ test_worker() {
         
         # Make the request with unique agent headers and capture body + status code
         response=$(curl -s \
-          -H "x-agent: $AGENT_ID" \
-          -H "x-Agent: $AGENT_ID" \
-          -H "User-Agent: prisma-rate-limit-test/$AGENT_ID" \
           -w "%{http_code}" \
           -o /tmp/response_$i.json \
           "$endpoint" 2>/dev/null)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rate limiting is now enforced per client (by agent/IP) for consistent throttling across environments.
  * Request allowance reduced to 10 requests per 60 seconds on create/claim endpoints.
  * Rate-limit responses now return a structured JSON error including client IP and trace identifier.

* **Refactor**
  * Rate-limiter key updated to use client identity (no public API changes).

* **Tests**
  * Rate-limit test script accepts agent_id, sends identifying headers, and defaults to hosted endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->