### PR TITLE
Use verify-full sslmode

### DIFF
--- a/apps/claim-db-worker/app/web/DatabaseContext.tsx
+++ b/apps/claim-db-worker/app/web/DatabaseContext.tsx
@@ -90,7 +90,7 @@ export const DatabaseProvider = ({ children }: DatabaseProviderProps) => {
 
       if (db) {
         const directConnString = db.directConnection
-          ? `postgresql://${db.directConnection.user}:${db.directConnection.pass}@${db.directConnection.host}?sslmode=require`
+          ? `postgresql://${db.directConnection.user}:${db.directConnection.pass}@${db.directConnection.host}?sslmode=verify-full`
           : "";
 
         const newDbInfo = {

--- a/packages/create-db/README.md
+++ b/packages/create-db/README.md
@@ -111,7 +111,7 @@ When using `--json` with `create`, the output includes:
 ```json
 {
   "success": true,
-  "connectionString": "postgresql://user:pass@host:5432/postgres?sslmode=require",
+  "connectionString": "postgresql://user:pass@host:5432/postgres?sslmode=verify-full",
   "claimUrl": "https://create-db.prisma.io/claim?projectID=...",
   "deletionDate": "2025-12-13T12:00:00.000Z",
   "region": "us-east-1",
@@ -137,7 +137,7 @@ When using `--json` with `regions`, the output is an array of region objects:
 When using `--env`, the following variables are appended to the specified file:
 
 ```env
-DATABASE_URL="postgresql://user:pass@host:5432/postgres?sslmode=require"
+DATABASE_URL="postgresql://user:pass@host:5432/postgres?sslmode=verify-full"
 CLAIM_URL="https://create-db.prisma.io/claim?projectID=..."
 ```
 

--- a/packages/create-db/src/core/database.ts
+++ b/packages/create-db/src/core/database.ts
@@ -121,10 +121,15 @@ export async function createDatabaseCore(
       Boolean(c.endpoints?.direct?.connectionString) ||
       Boolean(c.endpoints?.pooled?.connectionString),
   );
-  const connectionString =
+  const rawConnectionString =
     connection?.endpoints?.direct?.connectionString
     ?? connection?.endpoints?.pooled?.connectionString
     ?? null;
+  const connectionString =
+    rawConnectionString?.replace(
+      /([?&]sslmode=)(require|prefer|verify-ca)(?=[&#]|$)/i,
+      "$1verify-full"
+    ) ?? null;
 
   const claimUrl = `${claimDbWorkerUrl}/claim?projectID=${projectId}&utm_source=${userAgent || getCommandName()}&utm_medium=cli`;
 


### PR DESCRIPTION
## Summary
- Replace the direct claim UI connection string suffix from `sslmode=require` to `sslmode=verify-full`.
- Update create-db README examples to show `sslmode=verify-full`.

## Validation
- `pnpm test`